### PR TITLE
update init to fix plugin loading

### DIFF
--- a/pstqgis/src/pst/__init__.py
+++ b/pstqgis/src/pst/__init__.py
@@ -30,7 +30,7 @@ def MetaData():
 		my_dir = os.path.dirname(os.path.abspath(__file__))
 		metadata_path = os.path.join(my_dir, 'metadata.txt')
 		metadata = configparser.ConfigParser()
-		metadata.read(metadata_path)
+		metadata.read(metadata_path, encoding='utf8')
 	return metadata
 
 APP_TITLE = MetaData()['general']['name']


### PR DESCRIPTION
Fix #2 
Added explicit utf8 encoding option to metadata.read() ot prevent "UnicodeDecodeError: 'ascii' codec can't decode byte" error.
I hope this does not break Windows and Linux compatibility.